### PR TITLE
Add support for F# projects

### DIFF
--- a/Commands/SolutionParserCommand.cs
+++ b/Commands/SolutionParserCommand.cs
@@ -34,7 +34,9 @@ public sealed class SolutionParserCommand : Command<SolutionParserCommand.Settin
 
         if (!solutionPath.EndsWith(".sln") && Directory.Exists(solutionPath))
         {
-            projFiles = Directory.GetFiles(solutionPath, "*.csproj")
+            string[] projFileGlobs = ["*.csproj", "*.fsproj"];
+            projFiles = projFileGlobs
+                .SelectMany(glob => Directory.GetFiles(solutionPath, glob))
                 .Select(p => new ProjectRecord(Path.GetFileNameWithoutExtension(p), p));
         }
 


### PR DESCRIPTION
I noticed that the vscode extension doesn't support F# based projects. According to the extensions output it didn't find any projects to build. I tracked this down to the hardcoded check for *.csproj files here. A simple test with the added *.fsproj glob here gave me a working preview in VSCode.