### PR TITLE
Fix #3 Error parsing project by updating Microsoft.Build dependency

### DIFF
--- a/SolutionParser.csproj
+++ b/SolutionParser.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.7.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.7.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.11.4" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves issues parsing some newer projects by updating to the latest Microsoft.Build and Microsoft.Build.Utilities.Core