### PR TITLE
Use MSBuild locator

### DIFF
--- a/SolutionParser.csproj
+++ b/SolutionParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,7 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Spectre.Console" Version="0.47.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageReference Include="Microsoft.Build" Version="17.11.4" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8"  />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR removes the direct runtime package dependency to MSBuild.

That dependency caused several issues, since the actually located MSBuild installation might be different from the referenced one. You could have a mix of local assemblies and assemblies from the .NET SDK being loaded inside the same process, causing runtime errors.

It was also possible that the runtime MSBuild version was actually from an unsupported .NET version, effectively trying to load .NET 9 assemblies into .NET 8, and crashing.

To solve these problems, [MSBuild Locator](https://learn.microsoft.com/en-us/visualstudio/msbuild/find-and-use-msbuild-versions?view=vs-2022#use-microsoftbuildlocator) is now used instead:
 - No MSBuild assemblies are present in the output folder, they're always loaded from a matching .NET SDK.
 - The SDK found can't have a higher version that the current runtime.
 - The solution's global.json SDK is respected.

As part of this fix, the SolutionParser now targets .NET 9, so it can load MSBuild from the .NET 9 SDK if projects require it.

Fixes #5 and several related AvaloniaVSCode issues (I'll link them when updating the SolutionParser submodule there).